### PR TITLE
ActiveStorage: enable direct_upload

### DIFF
--- a/app/assets/javascripts/direct_uploads.js
+++ b/app/assets/javascripts/direct_uploads.js
@@ -1,0 +1,39 @@
+// direct_uploads.js
+// http://edgeguides.rubyonrails.org/active_storage_overview.html#example
+
+addEventListener("direct-upload:initialize", event => {
+  const { target, detail } = event
+  const { id, file } = detail
+  target.insertAdjacentHTML("beforebegin", `
+    <div id="direct-upload-${id}" class="direct-upload direct-upload--pending">
+      <div id="direct-upload-progress-${id}" class="direct-upload__progress" style="width: 0%"></div>
+      <span class="direct-upload__filename">${file.name}</span>
+    </div>
+  `)
+})
+
+addEventListener("direct-upload:start", event => {
+  const { id } = event.detail
+  const element = document.getElementById(`direct-upload-${id}`)
+  element.classList.remove("direct-upload--pending")
+})
+
+addEventListener("direct-upload:progress", event => {
+  const { id, progress } = event.detail
+  const progressElement = document.getElementById(`direct-upload-progress-${id}`)
+  progressElement.style.width = `${progress}%`
+})
+
+addEventListener("direct-upload:error", event => {
+  event.preventDefault()
+  const { id, error } = event.detail
+  const element = document.getElementById(`direct-upload-${id}`)
+  element.classList.add("direct-upload--error")
+  element.setAttribute("title", error)
+})
+
+addEventListener("direct-upload:end", event => {
+  const { id } = event.detail
+  const element = document.getElementById(`direct-upload-${id}`)
+  element.classList.add("direct-upload--complete")
+})

--- a/app/assets/stylesheets/direct_uploads.css
+++ b/app/assets/stylesheets/direct_uploads.css
@@ -1,0 +1,39 @@
+/* direct_uploads.css */
+
+.direct-upload {
+  display: inline-block;
+  position: relative;
+  padding: 2px 4px;
+  margin: 0 3px 3px 0;
+  border: 1px solid rgba(0, 0, 0, 0.3);
+  border-radius: 3px;
+  font-size: 11px;
+  line-height: 13px;
+}
+
+.direct-upload--pending {
+  opacity: 0.6;
+}
+
+.direct-upload__progress {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  opacity: 0.2;
+  background: rgba(46, 36, 36, 1.0);
+  transition: width 120ms ease-out, opacity 60ms 60ms ease-in;
+  transform: translate3d(0, 0, 0);
+}
+
+.direct-upload--complete .direct-upload__progress {
+  opacity: 0.4;
+}
+
+.direct-upload--error {
+  border-color: rgba(192, 57, 43, 1.0);
+}
+
+input[type=file][data-direct-upload-url][disabled] {
+  display: none;
+}

--- a/app/views/welcome/_upload.html.erb
+++ b/app/views/welcome/_upload.html.erb
@@ -11,7 +11,7 @@
     </div>
   <% end %>
   <div class="form-group">
-    <%= form.file_field :attachment %><br>
+    <%= form.file_field :attachment, direct_upload: true %><br>
   </div>
   <div class="actions">
     <%= form.submit("Upload File", class: "btn btn-primary btn-lg") %>


### PR DESCRIPTION
This is the JS and CSS required to enable direct upload with Active Storage, plus actually enabling direct_upload option in the form. In light of Heroku's 30 second timeouts on dynos, direct upload to s3 or other cloud service will prevent [H12](https://devcenter.heroku.com/articles/error-codes#h12-request-timeout) errors.
Refer to: http://guides.rubyonrails.org/active_storage_overview.html#direct-uploads